### PR TITLE
fix: copy-paste bugs, select case order, and safety checks

### DIFF
--- a/adapt/adapt.go
+++ b/adapt/adapt.go
@@ -37,6 +37,9 @@ func NewSecurities(codes []string) []*qotcommon.Security {
 
 // SecurityToCode converts a Security to a code string, e.g. "HK.00700".
 func SecurityToCode(s *qotcommon.Security) string {
+	if s == nil {
+		return ""
+	}
 	return GetMarketName(s.GetMarket()) + "." + s.GetCode()
 }
 
@@ -125,7 +128,9 @@ func NewCustomIndicatorFilter(opts ...Option) *qotstockfilter.CustomIndicatorFil
 	o["isNoFilter"] = false
 
 	var f qotstockfilter.CustomIndicatorFilter
-	_ = o.ToProto(&f)
+	if err := o.ToProto(&f); err != nil {
+		return nil
+	}
 
 	return &f
 }
@@ -134,7 +139,9 @@ func NewCustomIndicatorFilter(opts ...Option) *qotstockfilter.CustomIndicatorFil
 func NewFilterConditions(opts ...Option) *trdcommon.TrdFilterConditions {
 	o := NewOptions(opts...)
 	var f trdcommon.TrdFilterConditions
-	_ = o.ToProto(&f)
+	if err := o.ToProto(&f); err != nil {
+		return nil
+	}
 
 	return &f
 }

--- a/client/quote.go
+++ b/client/quote.go
@@ -805,13 +805,13 @@ func (client *Client) QotGetMarketState(ctx context.Context, c2s *qotgetmarketst
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
+	case <-client.closed:
+		return nil, ErrInterrupted
 	case resp, ok := <-ch:
 		if !ok {
 			return nil, ErrChannelClosed
 		}
 		return resp.GetS2C(), infra.Error(resp)
-	case <-client.closed:
-		return nil, ErrInterrupted
 	}
 }
 
@@ -830,12 +830,12 @@ func (client *Client) QotGetOptionExpirationDate(ctx context.Context, c2s *qotge
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
+	case <-client.closed:
+		return nil, ErrInterrupted
 	case resp, ok := <-ch:
 		if !ok {
 			return nil, ErrChannelClosed
 		}
 		return resp.GetS2C(), infra.Error(resp)
-	case <-client.closed:
-		return nil, ErrInterrupted
 	}
 }

--- a/client/trade_test.go
+++ b/client/trade_test.go
@@ -56,8 +56,8 @@ func (ts *ClientTestSuite) TestTrdGetAccList_TrdGetFunds() {
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
 		res, err := ts.client.TrdGetFunds(ctx, c2s)
+		cancel()
 		should.NoError(err)
 		log.Info().Interface("data", res.GetFunds()).Msg("TrdGetFunds")
 	}

--- a/sdk.go
+++ b/sdk.go
@@ -135,7 +135,7 @@ func (sdk *SDK) GetPositionList(header *trdcommon.TrdHeader, opts ...adapt.Optio
 	return sdk.GetPositionListWithContext(ctx, header, opts...)
 }
 
-// GetOrderList 2111 - gets the maximum available trading quantities.
+// GetMaxTrdQtys 2111 - gets the maximum available trading quantities.
 //
 // header: trading header
 //
@@ -193,7 +193,7 @@ func (sdk *SDK) ModifyOrder(header *trdcommon.TrdHeader, orderID uint64, modifyO
 	return sdk.ModifyOrderWithContext(ctx, header, orderID, modifyOrderOp, opts...)
 }
 
-// GetHistoryOrderList 2211 - gets the filled order list.
+// GetOrderFillList 2211 - gets the filled order list.
 func (sdk *SDK) GetOrderFillList(header *trdcommon.TrdHeader, opts ...adapt.Option) ([]*trdcommon.OrderFill, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()


### PR DESCRIPTION
## Summary

- **`sdk.go`**: Fixed two incorrect godoc comments — `GetOrderList` → `GetMaxTrdQtys` and `GetHistoryOrderList` → `GetOrderFillList` (copy-paste errors from adjacent methods)
- **`client/quote.go`**: Reordered `select` cases in `QotGetMarketState` and `QotGetOptionExpirationDate` to match the standard `<-ctx.Done()` / `<-client.closed` / `<-ch` pattern used in every other function
- **`client/trade_test.go`**: Replaced `defer cancel()` with immediate `cancel()` call inside a `for` loop — `defer` is function-scoped, so cancel functions were accumulating until function exit
- **`adapt/adapt.go`**: Added nil guard to `SecurityToCode` to prevent nil pointer panic; changed `NewCustomIndicatorFilter` and `NewFilterConditions` to return `nil` on `ToProto` error instead of silently discarding it

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./adapt/... ./infra/...` passes
- [ ] Integration tests (`go test ./...`) require live FutuOpenD instance


💘 Generated with Crush